### PR TITLE
Feat/3 common auth exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,12 @@ java {
     }
 }
 
-// 실행 가능한 JAR 비활성화, 일반 라이브러리 JAR 활성화
+// 실행 가능한 JAR 비활성화, 일반 라이브러리 JAR 활성화 (-plain 접미사 제거)
 bootJar.enabled = false
-jar.enabled = true
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
 
 repositories {
     mavenCentral()
@@ -26,6 +29,7 @@ repositories {
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-web'
     api 'org.springframework.boot:spring-boot-starter-validation'
+    api 'org.springframework.boot:spring-boot-starter-security'
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'org.springframework.boot:spring-boot-starter-data-redis'
     api 'org.springframework.kafka:spring-kafka'

--- a/src/main/java/com/finlearn/common/exception/AuthErrorCode.java
+++ b/src/main/java/com/finlearn/common/exception/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package com.finlearn.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/** JWT 인증/인가 관련 에러 코드 **/
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode {
+
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않는다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 Access Token이다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Access Token이다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 Refresh Token이다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/finlearn/common/security/HeaderUserDetails.java
+++ b/src/main/java/com/finlearn/common/security/HeaderUserDetails.java
@@ -30,8 +30,4 @@ public class HeaderUserDetails implements UserDetails {
 
     @Override public String getPassword() { return null; }
     @Override public String getUsername() { return email; }
-    @Override public boolean isAccountNonExpired() { return true; }
-    @Override public boolean isAccountNonLocked() { return true; }
-    @Override public boolean isCredentialsNonExpired() { return true; }
-    @Override public boolean isEnabled() { return true; }
 }

--- a/src/main/java/com/finlearn/common/security/HeaderUserDetails.java
+++ b/src/main/java/com/finlearn/common/security/HeaderUserDetails.java
@@ -1,0 +1,37 @@
+package com.finlearn.common.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+/** Gateway가 주입한 X-User-* 헤더로 구성하는 UserDetails 구현체.*/
+@Getter
+public class HeaderUserDetails implements UserDetails {
+
+    private final UUID userId;
+    private final String email;
+    private final String role;
+
+    public HeaderUserDetails(UUID userId, String email, String role) {
+        this.userId = userId;
+        this.email = email;
+        this.role = role;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    @Override public String getPassword() { return null; }
+    @Override public String getUsername() { return email; }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/finlearn/common/security/SecurityConfig.java
+++ b/src/main/java/com/finlearn/common/security/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.finlearn.common.security;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * 다운스트림 마이크로서비스용 기본 Security 설정.
+ * 서비스가 직접 SecurityFilterChain 빈을 등록하면 이 설정은 적용되지 않는다.
+ */
+@Configuration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class SecurityConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public UserHeaderFilter userHeaderFilter() {
+        return new UserHeaderFilter();
+    }
+
+    /**
+     * Gateway에서 이미 JWT 검증을 완료했으므로 모든 요청을 허용하고,
+     * UserHeaderFilter로 SecurityContext만 구성한다.
+     * 서비스별 SecurityFilterChain이 있으면 이 빈은 생성되지 않는다.
+     */
+    @Bean
+    @ConditionalOnMissingBean(SecurityFilterChain.class)
+    public SecurityFilterChain defaultFilterChain(HttpSecurity http,
+                                                   UserHeaderFilter userHeaderFilter) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .addFilterBefore(userHeaderFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/finlearn/common/security/UserHeaderFilter.java
+++ b/src/main/java/com/finlearn/common/security/UserHeaderFilter.java
@@ -1,0 +1,41 @@
+package com.finlearn.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/** Gateway가 검증 후 주입한 X-User-* 헤더를 읽어 SecurityContext를 구성하는 필터 */
+public class UserHeaderFilter extends OncePerRequestFilter {
+
+    public static final String HEADER_USER_ID    = "X-User-Id";
+    public static final String HEADER_USER_EMAIL = "X-User-Email";
+    public static final String HEADER_USER_ROLE  = "X-User-Role";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String userIdHeader = request.getHeader(HEADER_USER_ID);
+        String email        = request.getHeader(HEADER_USER_EMAIL);
+        String role         = request.getHeader(HEADER_USER_ROLE);
+
+        // userId와 role이 있으면 SecurityContext 구성 (email은 JWT에 포함되지 않아 null일 수 있음)
+        if (userIdHeader != null && role != null) {
+            UUID userId = UUID.fromString(userIdHeader);
+            HeaderUserDetails userDetails = new HeaderUserDetails(userId, email, role);
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+            );
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/finlearn/common/util/SecurityUtil.java
+++ b/src/main/java/com/finlearn/common/util/SecurityUtil.java
@@ -1,0 +1,36 @@
+package com.finlearn.common.util;
+
+import com.finlearn.common.security.HeaderUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.UUID;
+
+/** SecurityContext에서 현재 인증된 유저 정보를 꺼내는 편의 유틸리티. */
+public class SecurityUtil {
+
+    private SecurityUtil() {}
+
+    // 현재 요청의 userId를 반환한다.
+    public static UUID getCurrentUserId() {
+        return getUserDetails().getUserId();
+    }
+
+    // 현재 요청의 email을 반환한다.
+    public static String getCurrentUserEmail() {
+        return getUserDetails().getEmail();
+    }
+
+    // 현재 요청의 role을 반환한다.
+    public static String getCurrentUserRole() {
+        return getUserDetails().getRole();
+    }
+
+    private static HeaderUserDetails getUserDetails() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof HeaderUserDetails)) {
+            throw new IllegalStateException("인증된 사용자 정보가 없다.");
+        }
+        return (HeaderUserDetails) authentication.getPrincipal();
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.finlearn.common.config.CommonAutoConfiguration
+com.finlearn.common.security.SecurityConfig


### PR DESCRIPTION
## 🌱 설명
- `spring-boot-starter-security` 의존성 추가
- JWT 인증 에러 코드 `AuthErrorCode` 추가
- Gateway가 주입한 `X-User-*` 헤더를 읽어 `SecurityContext`를 구성하는 헤더 기반 인증 공통 모듈 구현
  - `HeaderUserDetails` : userId(UUID), email, role을 담는 UserDetails 구현체
  - `UserHeaderFilter` : X-User-Id, X-User-Role 헤더 → SecurityContext 구성 필터
  - `SecurityConfig` : 다운스트림 서비스에 UserHeaderFilter 자동 등록 (서비스 자체 SecurityFilterChain이 있으면 미적용)
  - `SecurityUtil` : getCurrentUserId() 등 SecurityContext 편의 유틸

## 📌 관련 이슈
close #3

## 💻 커밋 유형
- [x] feat : 새로운 기능 추가
- [x] chore : 빌드 설정, 의존성 업데이트 등

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
**[공유] 다운스트림 서비스 Security 설정 자동화**

`SecurityConfig`를 `AutoConfiguration`에 등록했기 때문에
quiz-service, ranking-service 등 다운스트림 서비스는 **별도 Security 설정 없이** 자동으로 `UserHeaderFilter`가 등록됩니다.

단, 서비스가 자체 `SecurityFilterChain` 빈을 등록하면 common의 기본 설정은 적용되지 않습니다.
(`@ConditionalOnMissingBean(SecurityFilterChain.class)` 조건)

**[공유] userId 타입 통일**

기존 `HeaderUserDetails`의 userId 타입이 `Long`이었으나,
user-service의 userId가 `UUID` 기반임에 맞춰 `UUID`로 수정했습니다.
`SecurityUtil.getCurrentUserId()`의 반환 타입도 동일하게 변경되었으므로
해당 메서드를 사용하는 서비스는 타입 확인이 필요합니다.