### PR TITLE
[feat] ErrorResponse에 code 필드 추가

### DIFF
--- a/src/main/java/com/finlearn/common/exception/GlobalExceptionAdviceImpl.java
+++ b/src/main/java/com/finlearn/common/exception/GlobalExceptionAdviceImpl.java
@@ -26,7 +26,7 @@ public class GlobalExceptionAdviceImpl {
 
         return ResponseEntity
                 .status(e.getStatus())
-                .body(ErrorResponse.of(e.getStatus(), e.getField(), e.getMessage()));
+                .body(ErrorResponse.of(e.getStatus(), e.getCode(), e.getField(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/finlearn/common/response/ErrorResponse.java
+++ b/src/main/java/com/finlearn/common/response/ErrorResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 public record ErrorResponse(
         int status,
         String error,
+        String code,
         Object message,
         String field,
         String traceId,
@@ -17,6 +18,7 @@ public record ErrorResponse(
         return new ErrorResponse(
                 status.value(),
                 status.name(),
+                null,
                 message,
                 null,
                 MDC.get("traceId"),
@@ -28,6 +30,19 @@ public record ErrorResponse(
         return new ErrorResponse(
                 status.value(),
                 status.name(),
+                null,
+                message,
+                field,
+                MDC.get("traceId"),
+                LocalDateTime.now()
+        );
+    }
+
+    public static ErrorResponse of(HttpStatus status, String code, String field, Object message) {
+        return new ErrorResponse(
+                status.value(),
+                status.name(),
+                code,
                 message,
                 field,
                 MDC.get("traceId"),


### PR DESCRIPTION
## 🌱 설명
- 공통 예외 응답 포맷에 비즈니스 에러 코드를 포함하기 위해 `ErrorResponse`에 `code` 필드를 추가했습니다.
- `CustomException` 발생 시 해당 코드가 응답에 포함되도록 `GlobalExceptionAdviceImpl`을 수정했습니다.

## 📌 관련 이슈
- close #8 

## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat : 새로운 기능 추가
- [ ] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [ ] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
- 기존 예외 응답과의 하위 호환성을 유지하기 위해 `code` 값이 null인 경우 응답에 포함되지 않도록 했습니다.
- Validation / Body 파싱 등 기존 예외 흐름은 변경 없이 유지됩니다.
- 클라이언트에서 HTTP status 외에 비즈니스 에러 코드를 기준으로 분기 처리할 수 있도록 확장했습니다.