### PR TITLE
[Fix] JpaAuditConfig 수정

### DIFF
--- a/src/main/java/com/finlearn/common/config/CommonAutoConfiguration.java
+++ b/src/main/java/com/finlearn/common/config/CommonAutoConfiguration.java
@@ -1,36 +1,17 @@
 package com.finlearn.common.config;
 
 import com.finlearn.common.exception.GlobalExceptionAdviceImpl;
+import com.finlearn.common.filter.MdcLoggingFilter;
 import com.finlearn.common.response.CommonResponseAdvice;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
-import com.finlearn.common.filter.MdcLoggingFilter;
 
 @AutoConfiguration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class CommonAutoConfiguration {
-
-    @Bean
-    @ConditionalOnMissingBean
-    public JpaAuditConfig jpaAuditConfig() {
-        return new JpaAuditConfig();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public RedisConfig redisConfig() {
-        return new RedisConfig();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public KafkaConfig kafkaConfig(KafkaProperties kafkaProperties) {
-        return new KafkaConfig(kafkaProperties);
-    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/src/main/java/com/finlearn/common/config/JpaAuditConfig.java
+++ b/src/main/java/com/finlearn/common/config/JpaAuditConfig.java
@@ -1,9 +1,22 @@
 package com.finlearn.common.config;
 
+import com.finlearn.common.security.UserAuditorAware;
+import java.util.UUID;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
+@ConditionalOnProperty(name = "spring.datasource.url")
 @EnableJpaAuditing
 public class JpaAuditConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AuditorAware<UUID> auditorProvider() {
+        return new UserAuditorAware();
+    }
 }

--- a/src/main/java/com/finlearn/common/security/UserAuditorAware.java
+++ b/src/main/java/com/finlearn/common/security/UserAuditorAware.java
@@ -1,0 +1,18 @@
+package com.finlearn.common.security;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class UserAuditorAware implements AuditorAware<UUID> {
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .filter(Authentication::isAuthenticated).map(Authentication::getPrincipal)
+                .filter(principal -> principal instanceof HeaderUserDetails)
+                .map(principal -> ((HeaderUserDetails) principal).getUserId());
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.finlearn.common.config.CommonAutoConfiguration
+com.finlearn.common.config.JpaAuditConfig
 com.finlearn.common.security.SecurityConfig


### PR DESCRIPTION
## 🌱 설명
1. JpaAuditConfig가 자동 적용되지 않고 있었어서 자동 적용되게 변경
2. AuditorAware 구현
3. Redis와 Kafka 설정도 자동 적용 안되고 있었지만 현 시점에 적용 시키기엔 무리가 있어 보여 적용 안하였음

## 📌 관련 이슈
close #10 

## 💻 커밋 유형
- [x] feat : 새로운 기능 추가
- [x] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [ ] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가


## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?