### PR TITLE
feat: add common swagger openapi config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     api 'io.zipkin.reporter2:zipkin-reporter-brave'
     api 'org.springframework.boot:spring-boot-starter-actuator'
     api 'io.micrometer:micrometer-tracing-bridge-brave'
+    api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/finlearn/common/config/OpenApiConfig.java
+++ b/src/main/java/com/finlearn/common/config/OpenApiConfig.java
@@ -1,0 +1,59 @@
+package com.finlearn.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class OpenApiConfig {
+
+    private static final String BEARER_AUTH = "BearerAuth";
+    private static final String USER_ID_HEADER = "XUserId";
+    private static final String USER_ROLE_HEADER = "XUserRole";
+    private static final String USER_NICKNAME_HEADER = "XUserNickname";
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OpenAPI finlearnOpenAPI(
+            @Value("${spring.application.name:finlearn-service}") String applicationName
+    ) {
+        return new OpenAPI()
+                .info(new Info()
+                        .title(toTitle(applicationName))
+                        .version("v1")
+                        .description("FinLearn API documentation"))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_AUTH, bearerAuthScheme())
+                        .addSecuritySchemes(USER_ID_HEADER, apiKeyHeaderScheme("X-User-Id"))
+                        .addSecuritySchemes(USER_ROLE_HEADER, apiKeyHeaderScheme("X-User-Role"))
+                        .addSecuritySchemes(USER_NICKNAME_HEADER, apiKeyHeaderScheme("X-User-Nickname")))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH));
+    }
+
+    private SecurityScheme bearerAuthScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+    }
+
+    private SecurityScheme apiKeyHeaderScheme(String headerName) {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name(headerName);
+    }
+
+    private String toTitle(String applicationName) {
+        String title = applicationName.replace('-', ' ').replace('_', ' ');
+        return "FinLearn " + title;
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.finlearn.common.config.CommonAutoConfiguration
+com.finlearn.common.config.OpenApiConfig
 com.finlearn.common.security.SecurityConfig

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path=/api-docs.html
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha


### PR DESCRIPTION
## Summary
- Add springdoc-openapi WebMVC UI dependency to the common module.
- Add shared OpenAPI auto-configuration for FinLearn services.
- Configure Swagger UI defaults at `/api-docs.html`.

## Impact
Services that depend on `com.finlearn:common` can expose Swagger UI and `/v3/api-docs` without adding service-local springdoc setup.

## Validation
- `common`: `sh gradlew compileJava`
- `common`: `sh gradlew publishToMavenLocal`
- Downstream service compile checks passed after publishing common locally.